### PR TITLE
feat: integrate Solana wallet providers

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
+import './globals.css'
+import { ReactNode } from 'react'
+import { Providers } from '../providers'
+import { WalletMultiButton } from '@solana/wallet-adapter-react-ui'
 
-export default function HomePage() {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <div style={{ textAlign: "center", marginTop: "2rem" }}>
-      <h2>Welcome to Time Locked Wallet dApp</h2>
-      <p>Connect your wallet to get started.</p>
-      <WalletMultiButton />
-    </div>
-  );
+    <html lang="en">
+      <body>
+        <Providers>
+          <header className="p-4 flex justify-end">
+            <WalletMultiButton />
+          </header>
+          {children}
+        </Providers>
+      </body>
+    </html>
+  )
 }


### PR DESCRIPTION
## Summary
- wrap Next.js app with Solana wallet providers
- show wallet connect button in root layout

## Testing
- `npm --prefix app run lint`
- `anchor test` *(fails: command not found)*
- `cargo install anchor-cli` *(fails: 403 when fetching crates index)*

------
https://chatgpt.com/codex/tasks/task_e_68ac602710fc83238888049a18044730